### PR TITLE
fix: POI creation fails due to date types mismatch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.abspath("../poi_map"))
 project = "poi-map"
 author = "giantmolecularcloud"
 copyright = f"{today.year} {author}"
-release = "1.1.0"
+release = "1.1.2"
 
 html_theme_options = {"body_max_width": "80%"}
 html_theme = "sphinx_rtd_theme"

--- a/poi_map/app/app.py
+++ b/poi_map/app/app.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date
+from datetime import date, datetime
 from typing import Any, Iterable
 
 import dash_bootstrap_components as dbc
@@ -423,7 +423,7 @@ class POIMapApp:
             click_data: dict,
             title: str,
             category: str,
-            date: date,
+            date: str,
             description: str,
             is_open_toast: bool,
             is_open_success: bool,
@@ -435,7 +435,7 @@ class POIMapApp:
             bool,
             str | None,
             str | None,
-            date,
+            str,
             str | None,
             int,
             list,
@@ -462,7 +462,7 @@ class POIMapApp:
                         "latitude": [lat],
                         "longitude": [lon],
                         "category": [np.array(category)],
-                        "date": [date],
+                        "date": [datetime.strptime(date, "%Y-%m-%d").date()],
                         "title": [title],
                         "description": [description],
                     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poi-map"
-version = "1.1.1"
+version = "1.1.2"
 description = ""
 authors = ["giantmolecularcloud"]
 readme = "README.md"


### PR DESCRIPTION
When creating a new POI, a bug could occur that prevents creation of the POI.
This was caused by inconsistent handling of dates as strings (from the Dash input) or datetime dates (in the database file).